### PR TITLE
Windows don't snap when grabbed near screen edge.

### DIFF
--- a/src/opensnap.c
+++ b/src/opensnap.c
@@ -90,6 +90,11 @@ int main(int argc, char **argv)
         if(verbose)
             printf("Mouse Coordinates: %d %d %d\n", mousepos.x, mousepos.y, mousepos.state );
         if((LEFTCLICK & mousepos.state)==LEFTCLICK){
+            if(!isdrag && isinitialclick) {
+                if(isTitlebarHit(dsp, &mousepos)){
+                    isdrag=1;
+                }
+            }
             if(relativeMousepos.y<=offset)
                 action=HIT_TOP;
             else if(relativeMousepos.x<=offset)
@@ -98,14 +103,8 @@ int main(int argc, char **argv)
                 action=HIT_RIGHT;
             else if(relativeMousepos.y>=scrinfo.screens[scrnn].height-offset-1)
                 action=HIT_BOTTOM;
-            else {
-                if(!isdrag && isinitialclick) {
-                    if(isTitlebarHit(dsp, &mousepos)){
-                        isdrag=1;
-                    }
-                }
+            else
                 action=0;
-            }
             isinitialclick=false;
         }
         if(verbose)printf("action is: %d, isdrag is: %d\n",action,isdrag);


### PR DESCRIPTION
When I grab the window titlebar close to one of the edges of the desktop (top, bottom, or sides), snapping does not work. I think the desired behavior should be to snap the window regardless of where the titlebar was initially grabbed.

I changed the code so that "isdrag" gets set to 1 in the failing cases.
